### PR TITLE
Retargeted 4.5 -> [4.5,)

### DIFF
--- a/PowerShellTools/Manifest/11.0/source.extension.vsixmanifest
+++ b/PowerShellTools/Manifest/11.0/source.extension.vsixmanifest
@@ -16,7 +16,7 @@
     <InstallationTarget Version="11.0" Id="Microsoft.VisualStudio.Pro" />
   </Installation>
   <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="4.5" />
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
     <Dependency Id="Microsoft.VisualStudio.MPF.11.0" DisplayName="Visual Studio MPF 11.0" d:Source="Installed" Version="11.0" />
   </Dependencies>
   <Assets>

--- a/PowerShellTools/Manifest/12.0/source.extension.vsixmanifest
+++ b/PowerShellTools/Manifest/12.0/source.extension.vsixmanifest
@@ -17,7 +17,7 @@
     <InstallationTarget Version="[14.0]" Id="Microsoft.VisualStudio.IntegratedShell" />
   </Installation>
   <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="4.5" />
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
     <Dependency Id="Microsoft.VisualStudio.MPF.11.0" DisplayName="Visual Studio MPF 11.0" d:Source="Installed" Version="11.0" />
   </Dependencies>
   <Assets>

--- a/PowerShellTools/source.extension.vsixmanifest
+++ b/PowerShellTools/source.extension.vsixmanifest
@@ -16,7 +16,7 @@
     <InstallationTarget Version="12.0" Id="Microsoft.VisualStudio.Pro" />
   </Installation>
   <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="4.5" />
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
     <Dependency Id="Microsoft.VisualStudio.MPF.11.0" DisplayName="Visual Studio MPF 11.0" d:Source="Installed" Version="11.0" />
   </Dependencies>
   <Assets>


### PR DESCRIPTION
Changed targeting in vsixmanifest to allow installation on boxes where an in place upgrade of .NET 4.5 has occurred (Visual Studio 2015 in-place upgrades .NET 4.5 to .NET 4.5.3, for example). Resolves #165.