### PR TITLE
Start startup file on project start

### DIFF
--- a/PowerShellTools/Project/PowerShellProjectLauncher.cs
+++ b/PowerShellTools/Project/PowerShellProjectLauncher.cs
@@ -35,16 +35,21 @@ namespace PowerShellTools.Project
         public int LaunchProject(bool debug)
         {
             string script = String.Empty;
-            var dte2 = (DTE2)Package.GetGlobalService(typeof(SDTE));
-            if (dte2 != null)
+            string startupFile = _project.GetStartupFile();
+
+            if (startupFile != null)
             {
-                if (dte2.ActiveDocument != null)
+                script = startupFile;
+            }
+            else
+            {
+                var dte2 = (DTE2)Package.GetGlobalService(typeof(SDTE));
+                if (dte2 != null)
                 {
-                    script = dte2.ActiveDocument.FullName;
-                }
-                else
-                {
-                    return VSConstants.E_INVALIDARG;
+                    if (dte2.ActiveDocument != null)
+                    {
+                        script = dte2.ActiveDocument.FullName;
+                    }
                 }
             }
 

--- a/PowerShellTools/Project/PowerShellProjectNodeProperties.cs
+++ b/PowerShellTools/Project/PowerShellProjectNodeProperties.cs
@@ -9,11 +9,11 @@ namespace PowerShellTools.Project
     [Guid(CommonConstants.ProjectNodePropertiesGuid)]
     public class PowerShellProjectNodeProperties : CommonProjectNodeProperties
     {
-        internal PowerShellProjectNodeProperties(ProjectNode node) : base(node)
+        internal PowerShellProjectNodeProperties(ProjectNode node)
+            : base(node)
         {
         }
 
-        public new string StartupFile { get; set; }
-
+        //public new string StartupFile { get; set; }
     }
 }

--- a/PowerShellTools/Project/SharedProject/CommonProjectNodeProperties.cs
+++ b/PowerShellTools/Project/SharedProject/CommonProjectNodeProperties.cs
@@ -38,11 +38,7 @@ namespace Microsoft.VisualStudioTools.Project {
         [SRDescriptionAttribute(SR.StartupFileDescription)]
         public string StartupFile {
             get {
-                var res = Node.ProjectMgr.GetProjectProperty(CommonConstants.StartupFile, true);
-                if (!Path.IsPathRooted(res)) {
-                    res = CommonUtils.GetAbsoluteFilePath(Node.ProjectMgr.ProjectHome, res);
-            }
-                return res;
+                return Node.ProjectMgr.GetProjectProperty(CommonConstants.StartupFile, true);
             }
             set {
                 this.Node.ProjectMgr.SetProjectProperty(CommonConstants.StartupFile, value);


### PR DESCRIPTION
Fixes issues #293 and #294 and also starts the set startup file if set, else it starts the currently active document (current behaviour). If neither is found it launches with an empty script instead of throwing a generic exception