### PR TITLE
Added try catch blocks to command formatting methods

### DIFF
--- a/PowerShellTools.Explorer/Helpers/ExceptionHandler.cs
+++ b/PowerShellTools.Explorer/Helpers/ExceptionHandler.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
 
 namespace PowerShellTools.Explorer
 {
@@ -14,6 +15,14 @@ namespace PowerShellTools.Explorer
 
         public void HandleException(Exception exception)
         {
+            // TODO: implement logging to poshtools logger
+            if (exception == null)
+            {
+                return;
+            }
+
+            var message = string.IsNullOrWhiteSpace(exception.Message) ? "Unknown exception" : exception.Message;
+            MessageBox.Show(message, "PowerShell Command Explorer", MessageBoxButton.OK);
         }
     }
 }

--- a/PowerShellTools.Explorer/UI/PSParameterEditorViewModel.cs
+++ b/PowerShellTools.Explorer/UI/PSParameterEditorViewModel.cs
@@ -180,13 +180,20 @@ namespace PowerShellTools.Explorer
 
         private void UpdateCommandPreview()
         {
-            CommandFormatterOptions options = new CommandFormatterOptions()
+            try
             {
-                FormateStyle = _options.FormatAsHashTable ? CommandFormatStyle.HashTable : CommandFormatStyle.Inline,
-                ParameterSet = _selectedItem
-            };
+                CommandFormatterOptions options = new CommandFormatterOptions()
+                {
+                    FormateStyle = _options.FormatAsHashTable ? CommandFormatStyle.HashTable : CommandFormatStyle.Inline,
+                    ParameterSet = _selectedItem
+                };
 
-            CommandPreview = CommandFormatter.FormatCommandModel(Model, options);
+                CommandPreview = CommandFormatter.FormatCommandModel(Model, options);
+            }
+            catch (Exception ex)
+            {
+                _exceptionHandler.HandleException(ex);
+            }
         }
 
         private void ViewDetails()
@@ -197,16 +204,23 @@ namespace PowerShellTools.Explorer
 
         private void Copy()
         {
-            // TODO: Get the value to copy directly from the command preview box
-            CommandFormatterOptions options = new CommandFormatterOptions()
+            try
             {
-                FormateStyle = _options.FormatAsHashTable ? CommandFormatStyle.HashTable : CommandFormatStyle.Inline,
-                ParameterSet = _selectedItem
-            };
+                // TODO: Get the value to copy directly from the command preview box
+                CommandFormatterOptions options = new CommandFormatterOptions()
+                {
+                    FormateStyle = _options.FormatAsHashTable ? CommandFormatStyle.HashTable : CommandFormatStyle.Inline,
+                    ParameterSet = _selectedItem
+                };
 
-            var command = CommandFormatter.FormatCommandModel(Model, options);
+                var command = CommandFormatter.FormatCommandModel(Model, options);
 
-            ClipboardHelper.SetText(command);
+                ClipboardHelper.SetText(command);
+            }
+            catch (Exception ex)
+            {
+                _exceptionHandler.HandleException(ex);
+            }
         }
 
         private void Cancel()


### PR DESCRIPTION
@adamdriscoll still can't repo issue #355 but throwing an intentional null ref exception from the copy method does crash VS so I've preemptively wrapped the command formatting calls into try/catch blocks just to be sure.

In this PR any exception thrown from the command formatting methods will show a message box with the exception message. I'm thinking it might be a good idea to eventually hook the command explorer into the logging of poshtools?