### PR TITLE
Check for null path in PowerShellTestExecutor.GetModulePath

### DIFF
--- a/PowerShellTools.TestAdapter/PowerShellTestExecutor.cs
+++ b/PowerShellTools.TestAdapter/PowerShellTestExecutor.cs
@@ -249,6 +249,9 @@ namespace PowerShellTools.TestAdapter
 
         private static string GetModulePath(string moduleName, string root)
         {
+            if (root == null)
+                return null;
+            
             // Default packages path for nuget.
             var packagesRoot = Path.Combine(root, "packages");
 


### PR DESCRIPTION
This fixes #407

This is a duplicate of #409 which was created by @thomas-worm-datev , but that PR was merged to master and it seems all development is now done in dev. 