### PR TITLE
Fixing VS 2017 frozen upon debug PS scripts

### DIFF
--- a/PowerShellTools.HostService.x86/PowerShellTools.HostService.x86.csproj
+++ b/PowerShellTools.HostService.x86/PowerShellTools.HostService.x86.csproj
@@ -76,19 +76,19 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="envdte, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
       <Private>False</Private>
     </Reference>
     <Reference Include="envdte100, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
       <Private>False</Private>
     </Reference>
     <Reference Include="envdte80, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
       <Private>False</Private>
     </Reference>
     <Reference Include="envdte90, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />

--- a/PowerShellTools.HostService/PowerShellTools.HostService.csproj
+++ b/PowerShellTools.HostService/PowerShellTools.HostService.csproj
@@ -79,19 +79,19 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="envdte, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
       <Private>False</Private>
     </Reference>
     <Reference Include="envdte100, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
       <Private>False</Private>
     </Reference>
     <Reference Include="envdte80, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
       <Private>False</Private>
     </Reference>
     <Reference Include="envdte90, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />

--- a/PowerShellTools/Service/ExecutionEngine.cs
+++ b/PowerShellTools/Service/ExecutionEngine.cs
@@ -21,7 +21,7 @@ namespace PowerShellTools.Service
         {
             if (!PowerShellToolsPackage.PowerShellHostInitialized)
             {
-                PowerShellToolsPackage.DebuggerReadyEvent.WaitOne();
+                PowerShellToolsPackage.DebuggerReadyEvent.WaitOne(TimeSpan.FromSeconds(10));
             }
 
             _debugger = PowerShellToolsPackage.Debugger;


### PR DESCRIPTION
In a previous commit I accidentally changed the "DTE" references in the host process projects to "embed interop type = false" and "copy local = false"; since the host processes don't run inside VS, this setting causes a runtime exception of "file not found" (the DTE PIA assemblies). The fix is to embed the DTE types by setting "Embed Interop Types" to True so we don't have to redistribute the DTE PIA files and still the host process can load the correct DTE types at runtime.

Also added a timeout (10 seconds) on the wait on host process initialization, so in case of other causes that fails the host process, PowerShell Tools won't freeze the VS instance forever.