### PR TITLE
Limit each VSIX installation target to corresponding VS versions

### DIFF
--- a/Build/Common.Build.targets
+++ b/Build/Common.Build.targets
@@ -41,7 +41,7 @@
   <PropertyGroup>
     <VsixVsTarget Condition=" '$(VSTarget)' == '12.0' ">[12.0, 14.0)</VsixVsTarget>
     <VsixVsTarget Condition=" '$(VSTarget)' == '14.0' ">[14.0, 15.0)</VsixVsTarget>
-    <VsixVsTarget Condition=" '$(VSTarget)' == '15.0' ">[15.0.26127.0, 16.0)</VsixVsTarget>
+    <VsixVsTarget Condition=" '$(VSTarget)' == '15.0' ">[15.0.26203.0, 16.0)</VsixVsTarget>
   </PropertyGroup>
 
   <!-- Returns the current build version. Used in .vsixmanifests to substitute our build version into them -->

--- a/Build/Common.Build.targets
+++ b/Build/Common.Build.targets
@@ -34,14 +34,14 @@
 
   <PropertyGroup>
     <VsixDisplayName Condition=" '$(VSTarget)' == '12.0' ">PowerShell Tools for Visual Studio 2013</VsixDisplayName>
-    <VsixDisplayName Condition=" '$(VSTarget)' == '14.0' ">PowerShell Tools for Visual Studio 2015 and 2017</VsixDisplayName>
+    <VsixDisplayName Condition=" '$(VSTarget)' == '14.0' ">PowerShell Tools for Visual Studio 2015</VsixDisplayName>
     <VsixDisplayName Condition=" '$(VSTarget)' == '15.0' ">PowerShell Tools for Visual Studio 2017</VsixDisplayName>
   </PropertyGroup>
 
   <PropertyGroup>
-    <VsixVsTarget Condition=" '$(VSTarget)' == '12.0' ">[$(VSTarget)]</VsixVsTarget>
-    <VsixVsTarget Condition=" '$(VSTarget)' == '14.0' ">[$(VSTarget)]</VsixVsTarget>
-    <VsixVsTarget Condition=" '$(VSTarget)' == '15.0' ">[$(VSTarget)]</VsixVsTarget>
+    <VsixVsTarget Condition=" '$(VSTarget)' == '12.0' ">[12.0, 14.0)</VsixVsTarget>
+    <VsixVsTarget Condition=" '$(VSTarget)' == '14.0' ">[14.0, 15.0)</VsixVsTarget>
+    <VsixVsTarget Condition=" '$(VSTarget)' == '15.0' ">[15.0.26127.0, 16.0)</VsixVsTarget>
   </PropertyGroup>
 
   <!-- Returns the current build version. Used in .vsixmanifests to substitute our build version into them -->


### PR DESCRIPTION
Since now we have a VS2017 version of the VSIX, the VS2015 version of the VSIX should no longer be allowed to installed on VS2017 to prevent unexpected behavior (e.g. someone accidentally installed both versions of the VSIX in VS2017).

Also, since the VS2017 RC and previous builds comes with the old VSIX, we should limit the new VSIX to be installable only on VS2017 RTW to avoid the same problem described above. The version number is not the final build number, but should be close enough.